### PR TITLE
Add cookbook rb-cgroup as dependency

### DIFF
--- a/packaging/rpm/redborder-cookbooks.spec
+++ b/packaging/rpm/redborder-cookbooks.spec
@@ -24,6 +24,7 @@ Requires: cookbook-rb-ips cookbook-snort cookbook-barnyard2
 #Requires: cookbook-ohai
 Requires: cookbook-cron
 Requires: cookbook-rb-aioutliers
+Requires: cookbook-rb-cgroup
 
 %description
 %{summary}


### PR DESCRIPTION
* This PR adds new dependency `cookbook-rb-cgroup` for install the cgroup cookbook in a redborder node